### PR TITLE
V-0.5: File Exclusion + Re Ingest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Prettier
+        run: npm run format:check
+
+      - name: Build
+        run: npm run check-types && node esbuild.js
+
+      - name: Start xvfb (for VS Code extension tests)
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y xvfb
+          /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+
+      - name: Test
+        run: npm run test
+        env:
+          DISPLAY: ":99"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,5 @@ jobs:
               run: npm run test
               env:
                   DISPLAY: ':99'
+                  # Avoid D-Bus "Could not parse server address" errors in headless CI
+                  DBUS_SESSION_BUS_ADDRESS: ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,40 +1,40 @@
 name: CI
 
 on:
-  push:
-  pull_request:
+    push:
+    pull_request:
 
 jobs:
-  build-lint-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    build-lint-test:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+                  cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+            - name: Install dependencies
+              run: npm ci
 
-      - name: Lint
-        run: npm run lint
+            - name: Lint
+              run: npm run lint
 
-      - name: Prettier
-        run: npm run format:check
+            - name: Prettier
+              run: npm run format:check
 
-      - name: Build
-        run: npm run check-types && node esbuild.js
+            - name: Build
+              run: npm run check-types && node esbuild.js
 
-      - name: Start xvfb (for VS Code extension tests)
-        run: |
-          sudo apt-get update -q
-          sudo apt-get install -y xvfb
-          /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+            - name: Start xvfb (for VS Code extension tests)
+              run: |
+                  sudo apt-get update -q
+                  sudo apt-get install -y xvfb
+                  /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
-      - name: Test
-        run: npm run test
-        env:
-          DISPLAY: ":99"
+            - name: Test
+              run: npm run test
+              env:
+                  DISPLAY: ':99'

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -6,4 +6,6 @@ export default defineConfig({
         ui: 'bdd',
         timeout: 10000,
     },
+    // Reduce D-Bus/GPU noise and improve stability in headless CI (e.g. GitHub Actions)
+    launchArgs: ['--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage'],
 });

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from '@vscode/test-cli';
+
+export default defineConfig({
+    files: 'out/test/**/*.test.js',
+    mocha: {
+        ui: 'bdd',
+        timeout: 10000,
+    },
+});

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,6 +9,7 @@ src/**
 esbuild.js
 vsc-extension-quickstart.md
 **/tsconfig.json
+**/tsconfig.*.json
 **/eslint.config.mjs
 **/*.map
 **/*.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [0.4.2] - .gitingestignore & settings support
+## [0.5.0] - .gitingestignore & Re-Ingest
 
 Added
 
-- **.gitingestignore** support: same format as `.gitignore`; the gitingest engine respects both `.gitignore` and `.gitingestignore` when building the digest.
-- **Settings support** for exclusions: new setting `gitingest.fileExclusions` (glob patterns, defaults: `**/node_modules`, `**/.git`) so you can exclude more paths from ingestion; applied in addition to ignore files.
+- **.gitingestignore** support: same format as `.gitignore`; the gitingest engine respects both `.gitignore` and `.gitingestignore` when building the digest. Exclude files from ingestion without adding them to `.gitignore`.
+- **Settings support** for exclusions: setting `gitingest.fileExclusions` (glob patterns, defaults: `**/node_modules`, `**/.git`) to exclude more paths from ingestion; applied in addition to ignore files.
+- **Re-Ingest:** Re-run ingest on the same folder without reselecting. Use the **Re-Ingest** button in the results panel after viewing a digest, or run **GitIngest: Re-Ingest Last Folder** from the Command Palette. Useful after making changes when you don't want to go through the selection process again.
 
 Changed
 
@@ -19,6 +20,7 @@ Changed
 Fixed
 
 - Resolved 3 high-severity npm audit issues in dev dependencies (serialize-javascript) via override; tests unchanged.
+- VSIX no longer ships test-only config (`tsconfig.*.json` excluded) for a smaller package.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.4.2] - .gitingestignore & settings support
+
+Added
+
+- **.gitingestignore** support: same format as `.gitignore`; the gitingest engine respects both `.gitignore` and `.gitingestignore` when building the digest.
+- **Settings support** for exclusions: new setting `gitingest.fileExclusions` (glob patterns, defaults: `**/node_modules`, `**/.git`) so you can exclude more paths from ingestion; applied in addition to ignore files.
+
+Changed
+
+- **Handler:** Cancel / closing the panel now properly stops the running ingest process; script runs with the repo root as working directory; shared command/args logic and clearer error handling in the Python handler.
+- **Services:** Analysis service validates the repo path and reads workspace file-exclusion settings before running; webview and result types tightened up; removed unused config and helpers.
+
+Fixed
+
+- Resolved 3 high-severity npm audit issues in dev dependencies (serialize-javascript) via override; tests unchanged.
+
+---
+
 ## [0.4.1] - Add to Ingest
 
 Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to GitIngest Extension
+
+Thank you for your interest in contributing to GitIngest Extension. This document will help you get started.
+
+## How to Contribute
+
+- **Report bugs** – Open an [issue](https://github.com/ShreyPurohit/gitingest-vsextension/issues) with steps to reproduce and your environment (OS, VS Code version, Python version).
+- **Suggest features** – Use [GitHub Discussions](https://github.com/ShreyPurohit/gitingest-vsextension/discussions) or open an issue with the "enhancement" label.
+- **Submit code** – Follow the development setup below, then open a pull request.
+
+## Development Setup
+
+1. **Clone the repository**
+
+    ```bash
+    git clone https://github.com/ShreyPurohit/gitingest-vsextension.git
+    cd gitingest-vsextension
+    ```
+
+2. **Install dependencies**
+
+    ```bash
+    npm install
+    ```
+
+3. **Build the extension**
+
+    ```bash
+    npm run compile
+    ```
+
+    This runs type-check, lint, and esbuild. Output is in `dist/extension.js`.
+
+4. **Run the extension**
+    - Open the repo folder in VS Code.
+    - Press `F5` or use **Run > Start Debugging** to launch the Extension Development Host with the extension loaded.
+
+5. **Run tests**
+    ```bash
+    npm run test
+    ```
+    Runs the test suite in the VS Code test environment. Ensure the extension is built first (`npm run compile` or `node esbuild.js`) so `dist/extension.js` is up to date.
+
+## Code Style
+
+- **TypeScript** – Use the project’s `tsconfig.json` and avoid `any` where possible.
+- **Linting** – Run `npm run lint` (ESLint). Fix any reported issues before submitting.
+- **Formatting** – Run `npm run format` (Prettier) to keep style consistent.
+
+## Pull Request Process
+
+1. Fork the repo and create a branch from `main` (e.g. `fix/issue-123` or `feat/reingest-docs`).
+2. Make your changes, add or update tests if applicable.
+3. Run `npm run compile` and `npm run test` and fix any failures.
+4. Run `npm run format` and commit the result.
+5. Open a PR against `main` with a clear description and, if relevant, a link to the issue.
+6. Address review feedback. Once approved, maintainers will merge.
+
+By contributing, you agree that your contributions will be licensed under the same [MIT License](LICENSE) that covers this project.
+
+## Questions
+
+- **Bugs or features:** [GitHub Issues](https://github.com/ShreyPurohit/gitingest-vsextension/issues)
+- **General contact:** You can reach out via the email in the [bugs](https://github.com/ShreyPurohit/gitingest-vsextension/blob/main/package.json) field in `package.json`.
+
+Thanks for helping make GitIngest Extension better.

--- a/README.md
+++ b/README.md
@@ -249,10 +249,15 @@ GitIngest handles these automatically:
 
 Access via **File > Preferences > Settings > Extensions > GitIngest**:
 
-- **File Exclusions** - Add custom patterns to ignore
-- **Analysis Depth** - Control analysis scope
-- **Auto Cleanup** - Enable/disable automatic staging cleanup
-- **UI Preferences** - Customize panel layouts
+- **Ingest Folder Name** – Folder name used to stage files when using "Add to Ingest" (default: `gitingest-ingest`).
+- **Delete After Ingest** – When enabled, the staging folder is removed after a successful analysis.
+- **File Exclusions** – Glob patterns to exclude from ingestion (e.g. `**/node_modules`, `**/*.min.js`). Applied in addition to `.gitignore` and `.gitingestignore`.
+
+### .gitingestignore
+
+You can add a **`.gitingestignore`** file in the root of the folder you are analyzing. It uses the same format as `.gitignore`. Files and folders listed there are excluded from ingestion but remain in version control, so you don't need to add them to `.gitignore` just to keep them out of the digest.
+
+The engine respects both `.gitignore` and `.gitingestignore` by default. A recent version of the gitingest Python package (e.g. 0.3.x) is required for `.gitingestignore` support.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -362,12 +362,12 @@ Your privacy and security are our top priorities:
 
 ## Contributing
 
-### Ways to Help
+GitIngest is open source and we welcome contributions.
 
-- 🌟 **Star the repository** - Help others discover GitIngest
-- 🐛 **Report bugs** - Help me improve the extension
-- 💡 **Suggest features** - Share your ideas for new functionality
-- 💡 **Connect with me** - [GitHub](https://github.com/ShreyPurohit/)
+- 🌟 **Star the repository** – Help others discover GitIngest
+- 🐛 **Report bugs** – [Open an issue](https://github.com/ShreyPurohit/gitingest-vsextension/issues)
+- 💡 **Suggest features** – Share ideas via [GitHub Discussions](https://github.com/ShreyPurohit/gitingest-vsextension/discussions) or issues
+- 🔧 **Contribute code** – See **[CONTRIBUTING.md](CONTRIBUTING.md)** for development setup, code style, and how to submit pull requests
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,26 @@
 {
     "name": "gitingest",
-    "version": "0.3.0",
+    "version": "0.4.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gitingest",
-            "version": "0.3.0",
+            "version": "0.4.2",
             "license": "MIT",
             "devDependencies": {
+                "@types/mocha": "^10.0.1",
                 "@types/node": "20.x",
                 "@types/vscode": "^1.54.0",
                 "@typescript-eslint/eslint-plugin": "^8.10.0",
                 "@typescript-eslint/parser": "^8.7.0",
+                "@vscode/test-cli": "^0.0.8",
+                "@vscode/test-electron": "^2.3.9",
                 "esbuild": "^0.25.9",
                 "eslint": "^9.27.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-prettier": "^5.2.1",
+                "mocha": "^10.2.0",
                 "npm-run-all": "^4.1.5",
                 "prettier": "^3.3.3",
                 "typescript": "^5.6.3"
@@ -24,6 +28,13 @@
             "engines": {
                 "vscode": "^1.63.0"
             }
+        },
+        "node_modules/@bcoe/v8-coverage": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+            "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.25.9",
@@ -523,9 +534,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -604,9 +615,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -705,6 +716,62 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@istanbuljs/schema": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+            "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -743,6 +810,17 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@pkgr/core": {
             "version": "0.2.9",
             "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -763,10 +841,24 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/istanbul-lib-coverage": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+            "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/mocha": {
+            "version": "10.0.10",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+            "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -1022,6 +1114,57 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/@vscode/test-cli": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/@vscode/test-cli/-/test-cli-0.0.8.tgz",
+            "integrity": "sha512-sBSMSDzJChiiDjmys2Q6uI4SIoUYf0t6oDsQO3ypaQ7udha9YD4e2On9e9VE5OBayZMpxbgJX+NudmCwJMdOIg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mocha": "^10.0.2",
+                "c8": "^9.1.0",
+                "chokidar": "^3.5.3",
+                "enhanced-resolve": "^5.15.0",
+                "glob": "^10.3.10",
+                "minimatch": "^9.0.3",
+                "mocha": "^10.2.0",
+                "supports-color": "^9.4.0",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "vscode-test": "out/bin.mjs"
+            }
+        },
+        "node_modules/@vscode/test-cli/node_modules/supports-color": {
+            "version": "9.4.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+            "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/@vscode/test-electron": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
+            "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.5",
+                "jszip": "^3.10.1",
+                "ora": "^8.1.0",
+                "semver": "^7.6.2"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1045,10 +1188,20 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1060,6 +1213,29 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ansi-colors": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
         "node_modules/ansi-styles": {
@@ -1076,6 +1252,20 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/anymatch": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/argparse": {
@@ -1157,6 +1347,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/binary-extensions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/brace-expansion": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -1178,6 +1381,39 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/c8": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/c8/-/c8-9.1.0.tgz",
+            "integrity": "sha512-mBWcT5iqNir1zIkzSPyI3NCR9EZCVI3WUD+AVO17MVWTSFNyUueXE82qTeampNtTr+ilN/5Ua3j24LgbCKjDVg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@bcoe/v8-coverage": "^0.2.3",
+                "@istanbuljs/schema": "^0.1.3",
+                "find-up": "^5.0.0",
+                "foreground-child": "^3.1.1",
+                "istanbul-lib-coverage": "^3.2.0",
+                "istanbul-lib-report": "^3.0.1",
+                "istanbul-reports": "^3.1.6",
+                "test-exclude": "^6.0.0",
+                "v8-to-istanbul": "^9.0.0",
+                "yargs": "^17.7.2",
+                "yargs-parser": "^21.1.1"
+            },
+            "bin": {
+                "c8": "bin/c8.js"
+            },
+            "engines": {
+                "node": ">=14.14.0"
             }
         },
         "node_modules/call-bind": {
@@ -1240,6 +1476,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1255,6 +1504,151 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chokidar": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/chokidar/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/cli-cursor": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "restore-cursor": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-spinners": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+            "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/cliui/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cliui/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
         "node_modules/color-convert": {
@@ -1281,6 +1675,20 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -1371,6 +1779,19 @@
                 }
             }
         },
+        "node_modules/decamelize": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+            "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1414,6 +1835,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/diff": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+            "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1427,6 +1858,34 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/enhanced-resolve": {
+            "version": "5.20.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+            "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.3.0"
+            },
+            "engines": {
+                "node": ">=10.13.0"
             }
         },
         "node_modules/error-ex": {
@@ -1617,6 +2076,16 @@
                 "@esbuild/win32-x64": "0.25.9"
             }
         },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -1800,9 +2269,9 @@
             }
         },
         "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2000,6 +2469,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/flat": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "bin": {
+                "flat": "cli.js"
+            }
+        },
         "node_modules/flat-cache": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -2035,6 +2514,45 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/function-bind": {
@@ -2076,6 +2594,29 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-east-asian-width": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+            "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/get-intrinsic": {
@@ -2133,6 +2674,28 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/glob-parent": {
@@ -2299,12 +2862,57 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "he": "bin/he"
+            }
+        },
         "node_modules/hosted-git-info": {
             "version": "2.8.9",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
             "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
         },
         "node_modules/ignore": {
             "version": "7.0.5",
@@ -2315,6 +2923,13 @@
             "engines": {
                 "node": ">= 4"
             }
+        },
+        "node_modules/immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/import-fresh": {
             "version": "3.3.1",
@@ -2342,6 +2957,25 @@
             "engines": {
                 "node": ">=0.8.19"
             }
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/internal-slot": {
             "version": "1.1.0",
@@ -2417,6 +3051,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "binary-extensions": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-boolean-object": {
@@ -2526,6 +3173,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-generator-function": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
@@ -2556,6 +3213,19 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-interactive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+            "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-map": {
@@ -2609,6 +3279,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-plain-obj": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-regex": {
@@ -2710,6 +3390,19 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -2770,10 +3463,65 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/istanbul-lib-coverage": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+            "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-report": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+            "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^4.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-reports": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+            "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2811,6 +3559,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/jszip": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+            "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+            "dev": true,
+            "license": "(MIT OR GPL-3.0-or-later)",
+            "dependencies": {
+                "lie": "~3.3.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "^1.0.5"
+            }
+        },
         "node_modules/keyv": {
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2833,6 +3594,16 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/lie": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "immediate": "~3.0.5"
             }
         },
         "node_modules/load-json-file": {
@@ -2873,6 +3644,46 @@
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/log-symbols": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/make-dir": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+            "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
@@ -2917,20 +3728,233 @@
                 "node": ">=8.6"
             }
         },
+        "node_modules/mimic-function": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/mocha": {
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+            "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-colors": "^4.1.3",
+                "browser-stdout": "^1.3.1",
+                "chokidar": "^3.5.3",
+                "debug": "^4.3.5",
+                "diff": "^5.2.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-up": "^5.0.0",
+                "glob": "^8.1.0",
+                "he": "^1.2.0",
+                "js-yaml": "^4.1.0",
+                "log-symbols": "^4.1.0",
+                "minimatch": "^5.1.6",
+                "ms": "^2.1.3",
+                "serialize-javascript": "^6.0.2",
+                "strip-json-comments": "^3.1.1",
+                "supports-color": "^8.1.1",
+                "workerpool": "^6.5.1",
+                "yargs": "^16.2.0",
+                "yargs-parser": "^20.2.9",
+                "yargs-unparser": "^2.0.0"
+            },
+            "bin": {
+                "_mocha": "bin/_mocha",
+                "mocha": "bin/mocha.js"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/mocha/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/mocha/node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/mocha/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/mocha/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/mocha/node_modules/minimatch": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/mocha/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/mocha/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/mocha/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/mocha/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/mocha/node_modules/yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/mocha/node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/ms": {
@@ -2975,6 +3999,16 @@
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver"
+            }
+        },
+        "node_modules/normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/npm-run-all": {
@@ -3097,9 +4131,9 @@
             }
         },
         "node_modules/npm-run-all/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -3222,6 +4256,32 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/onetime": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-function": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3238,6 +4298,111 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/ora": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+            "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^5.3.0",
+                "cli-cursor": "^5.0.0",
+                "cli-spinners": "^2.9.2",
+                "is-interactive": "^2.0.0",
+                "is-unicode-supported": "^2.0.0",
+                "log-symbols": "^6.0.0",
+                "stdin-discarder": "^0.2.2",
+                "string-width": "^7.2.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ora/node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/ora/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ora/node_modules/is-unicode-supported": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+            "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ora/node_modules/log-symbols": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+            "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^5.3.0",
+                "is-unicode-supported": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+            "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ora/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/own-keys": {
@@ -3290,6 +4455,20 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0"
+        },
+        "node_modules/pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "dev": true,
+            "license": "(MIT AND Zlib)"
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3327,6 +4506,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3343,6 +4532,23 @@
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/path-type": {
             "version": "3.0.0",
@@ -3442,6 +4648,13 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3488,6 +4701,42 @@
                 "node": ">=4"
             }
         },
+        "node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/readable-stream/node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
+            }
+        },
         "node_modules/reflect.getprototypeof": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -3532,6 +4781,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/resolve": {
             "version": "1.22.10",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -3561,6 +4820,23 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/restore-cursor": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "onetime": "^7.0.0",
+                "signal-exit": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/reusify": {
@@ -3618,6 +4894,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/safe-push-apply": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -3664,6 +4947,16 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/serialize-javascript": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+            "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/set-function-length": {
@@ -3714,6 +5007,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -3827,6 +5127,19 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/spdx-correct": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -3863,6 +5176,19 @@
             "dev": true,
             "license": "CC0-1.0"
         },
+        "node_modules/stdin-discarder": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+            "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/stop-iteration-iterator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -3875,6 +5201,80 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/string-width-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/string.prototype.padend": {
@@ -3955,6 +5355,46 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-bom": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -4018,6 +5458,81 @@
             },
             "funding": {
                 "url": "https://opencollective.com/synckit"
+            }
+        },
+        "node_modules/tapable": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+            "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/test-exclude": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+            "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@istanbuljs/schema": "^0.1.2",
+                "glob": "^7.1.4",
+                "minimatch": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/test-exclude/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/test-exclude/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/test-exclude/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/to-regex-range": {
@@ -4187,6 +5702,28 @@
                 "punycode": "^2.1.0"
             }
         },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/v8-to-istanbul": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+            "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.12",
+                "@types/istanbul-lib-coverage": "^2.0.1",
+                "convert-source-map": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.12.0"
+            }
+        },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -4311,6 +5848,215 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/workerpool": {
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+            "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs-unparser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+            "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "camelcase": "^6.0.0",
+                "decamelize": "^4.0.0",
+                "flat": "^5.0.2",
+                "is-plain-obj": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/yargs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gitingest",
-    "version": "0.4.2",
+    "version": "0.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gitingest",
-            "version": "0.4.2",
+            "version": "0.5.0",
             "license": "MIT",
             "devDependencies": {
                 "@types/mocha": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gitingest",
     "displayName": "Gitingest",
     "description": "Turn any repository into a simple text digest of its codebase.",
-    "version": "0.4.2",
+    "version": "0.5.0",
     "publisher": "iamshreydxv",
     "engines": {
         "vscode": "^1.63.0"
@@ -27,6 +27,11 @@
             {
                 "command": "vscode-gitingest.addToIngest",
                 "title": "GitIngest: Add to Ingest",
+                "category": "GitIngest"
+            },
+            {
+                "command": "vscode-gitingest.reIngest",
+                "title": "GitIngest: Re-Ingest Last Folder",
                 "category": "GitIngest"
             }
         ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gitingest",
     "displayName": "Gitingest",
     "description": "Turn any repository into a simple text digest of its codebase.",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "publisher": "iamshreydxv",
     "engines": {
         "vscode": "^1.63.0"
@@ -58,6 +58,15 @@
                     "default": false,
                     "description": "Whether to delete the staged files and folders after running GitIngest.",
                     "scope": "resource"
+                },
+                "gitingest.fileExclusions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": ["**/node_modules", "**/.git"],
+                    "description": "Glob patterns to exclude from ingestion (e.g. **/node_modules, **/*.min.js). Applied in addition to .gitignore and .gitingestignore. Defaults exclude node_modules and .git to avoid errors in deeply nested paths.",
+                    "scope": "resource"
                 }
             }
         }
@@ -72,10 +81,16 @@
         "check-types": "tsc --noEmit",
         "lint": "eslint src",
         "format": "prettier --write .",
-        "format:check": "prettier --check ."
+        "format:check": "prettier --check .",
+        "pretest": "tsc -p tsconfig.test.json",
+        "test": "vscode-test"
     },
     "devDependencies": {
+        "@types/mocha": "^10.0.1",
         "@types/vscode": "^1.54.0",
+        "@vscode/test-cli": "^0.0.8",
+        "@vscode/test-electron": "^2.3.9",
+        "mocha": "^10.2.0",
         "@types/node": "20.x",
         "@typescript-eslint/eslint-plugin": "^8.10.0",
         "@typescript-eslint/parser": "^8.7.0",
@@ -86,6 +101,9 @@
         "prettier": "^3.3.3",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1"
+    },
+    "overrides": {
+        "serialize-javascript": ">=7.0.3"
     },
     "keywords": [
         "gitingest",

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,4 @@ export const ERROR_MESSAGES = {
     VENV_CREATION_FAILED:
         'Failed to create virtual environment. The extension will try to install packages in user site-packages.',
     PERMISSION_ERROR: 'Permission denied. The extension will try to install in user site-packages.',
-    VENV_PERMISSION_ERROR:
-        'Permission denied while creating virtual environment. The extension will try to create it in the user home directory instead.',
 } as const;

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ export const COMMANDS = {
     analyze: 'vscode-gitingest.analyze',
     analyzeFolder: 'vscode-gitingest.analyzeFolder',
     addToIngest: 'vscode-gitingest.addToIngest',
+    reIngest: 'vscode-gitingest.reIngest',
 } as const;
 
 export const WEBVIEW_OPTIONS = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,17 +7,19 @@ import { processManager } from './utils/processManager';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     AnalysisService.setScriptPath(context);
+    AnalysisService.setContext(context);
 
-    const commands = registerCommands();
+    const commands = registerCommands(context);
 
     context.subscriptions.push(...commands);
 }
 
-function registerCommands(): vscode.Disposable[] {
+function registerCommands(context: vscode.ExtensionContext): vscode.Disposable[] {
     return [
         vscode.commands.registerCommand(COMMANDS.analyze, handleAnalyze),
         vscode.commands.registerCommand(COMMANDS.analyzeFolder, handleAnalyzeFolder),
         vscode.commands.registerCommand(COMMANDS.addToIngest, handleAddToIngest),
+        vscode.commands.registerCommand(COMMANDS.reIngest, () => handleReIngest(context)),
     ];
 }
 
@@ -83,5 +85,35 @@ async function handleAddToIngest(resourceUri: vscode.Uri): Promise<void> {
         const message =
             error instanceof Error ? error.message : 'Failed to add the selected item to ingest.';
         vscode.window.showErrorMessage(message);
+    }
+}
+
+async function handleReIngest(context: vscode.ExtensionContext): Promise<void> {
+    const lastPath = context.workspaceState.get<string>('gitingest.lastIngestedPath');
+    if (!lastPath || typeof lastPath !== 'string' || lastPath.trim() === '') {
+        vscode.window.showInformationMessage(
+            "No previous folder to re-ingest. Use 'Analyze' or 'Analyze This Folder' first.",
+        );
+        return;
+    }
+    const pathTrimmed = lastPath.trim();
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(pathTrimmed));
+    if (!workspaceFolder) {
+        context.workspaceState.update('gitingest.lastIngestedPath', undefined);
+        vscode.window.showWarningMessage(
+            'Last ingested folder is no longer in the workspace or no longer exists.',
+        );
+        return;
+    }
+    const panel = WebviewService.createAnalysisPanel('GitIngest: Re-Ingest');
+    panel.onDidDispose(() => {
+        processManager.killCurrentProcess().catch(console.error);
+    });
+    try {
+        await AnalysisService.verifyDependencies(panel);
+        await AnalysisService.analyze(panel, pathTrimmed, 'Re-analyzing folder...');
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+        WebviewService.showError(panel, 'Re-Ingest Failed', [errorMessage]);
     }
 }

--- a/src/gitingest-script.py
+++ b/src/gitingest-script.py
@@ -1,14 +1,43 @@
-from gitingest import ingest
-import sys
+"""GitIngest wrapper script. Receives repo path (argv[1]) in host OS form; argv[2] optional JSON array of extra exclude patterns."""
+from __future__ import annotations
+
 import json
+import sys
 
-repo = sys.argv[1]
-summary, tree, content = ingest(repo)
+from gitingest import ingest
 
-output = {
-    'summary': summary,
-    'tree': tree,
-    'content': content
-}
+# Always exclude these; some gitingest versions walk dirs and open .gitignore before
+# applying exclusions, which can raise FileNotFoundError inside node_modules/.git.
+# Pattern names are OS-agnostic (node_modules, .git exist on Windows, macOS, Linux).
+SAFE_EXCLUDE = {"**/node_modules", "**/.git", "node_modules", ".git"}
 
+if len(sys.argv) < 2 or not (sys.argv[1] or "").strip():
+    print("Error: repository path (argv[1]) is required.", file=sys.stderr)
+    sys.exit(1)
+
+repo = (sys.argv[1] or "").strip()
+exclude_patterns = set(SAFE_EXCLUDE)
+if len(sys.argv) > 2 and (sys.argv[2] or "").strip():
+    try:
+        patterns = json.loads(sys.argv[2])
+        if isinstance(patterns, list):
+            for p in patterns:
+                if isinstance(p, str) and p.strip():
+                    exclude_patterns.add(p.strip())
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+try:
+    summary, tree, content = ingest(repo, exclude_patterns=exclude_patterns)
+except FileNotFoundError as e:
+    err_str = str(e)
+    if "node_modules" in err_str or ".git" in err_str or ".gitignore" in err_str:
+        raise FileNotFoundError(
+            "GitIngest hit a missing .gitignore inside node_modules or .git. "
+            "Try analyzing only a subfolder (e.g. right-click 'src' -> GitIngest: Analyze This Folder), "
+            "or upgrade the gitingest package: pip install -U gitingest"
+        ) from e
+    raise
+
+output = {"summary": summary, "tree": tree, "content": content}
 print(json.dumps(output))

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -70,8 +70,29 @@ export class AnalysisService {
     }
 
     public static async getOutput(repoPath: string): Promise<AnalysisResult> {
+        const pathTrimmed = typeof repoPath === 'string' ? repoPath.trim() : '';
+        if (!pathTrimmed) {
+            return {
+                type: 'error',
+                message: 'Invalid or missing repository path.',
+            };
+        }
         try {
-            const output = await this.pythonHandler.executeScript(this.scriptPath, [repoPath]);
+            const resource =
+                vscode.workspace.getWorkspaceFolder(vscode.Uri.file(pathTrimmed))?.uri ??
+                WorkspaceService.getWorkspaceFolder()?.uri;
+            const fileExclusions =
+                (resource
+                    ? vscode.workspace
+                          .getConfiguration('gitingest', resource)
+                          .get<string[]>('fileExclusions', [])
+                    : []) ?? [];
+            const patterns = fileExclusions.filter(
+                (p): p is string => typeof p === 'string' && p.trim() !== '',
+            );
+            const args =
+                patterns.length > 0 ? [pathTrimmed, JSON.stringify(patterns)] : [pathTrimmed];
+            const output = await this.pythonHandler.executeScriptWithProcess(this.scriptPath, args);
             return {
                 type: 'success',
                 data: JSON.parse(output),

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -6,12 +6,19 @@ import { PythonHandler } from '../utils/pythonHandler';
 import { WebviewService } from './webviewService';
 import { WorkspaceService } from './workspaceService';
 
+const LAST_INGESTED_PATH_KEY = 'gitingest.lastIngestedPath';
+
 export class AnalysisService {
     private static pythonHandler = PythonHandler.getInstance();
     private static scriptPath: string;
+    private static extensionContext: vscode.ExtensionContext | undefined;
 
     public static setScriptPath(context: vscode.ExtensionContext): void {
         this.scriptPath = context.asAbsolutePath(path.join('src', 'gitingest-script.py'));
+    }
+
+    public static setContext(context: vscode.ExtensionContext): void {
+        this.extensionContext = context;
     }
 
     public static async verifyDependencies(panel: vscode.WebviewPanel): Promise<void> {
@@ -53,7 +60,10 @@ export class AnalysisService {
         }
 
         if (result.data) {
-            WebviewService.showResults(panel, result.data);
+            WebviewService.showResults(panel, result.data, targetPath);
+            if (this.extensionContext) {
+                this.extensionContext.workspaceState.update(LAST_INGESTED_PATH_KEY, targetPath);
+            }
             // After successfully showing results, attempt to clean up staged ingest folder
             try {
                 const workspaceRoot = WorkspaceService.getWorkspaceFolder();

--- a/src/services/messageHandler.ts
+++ b/src/services/messageHandler.ts
@@ -27,6 +27,9 @@ export async function handleWebviewMessage(
             case 'retry':
                 await handleAnalyzeCommand(panel);
                 break;
+            case 'reIngest':
+                await handleReIngestCommand(panel, message);
+                break;
         }
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : ERROR_MESSAGES.UNKNOWN_ERROR;
@@ -60,6 +63,34 @@ async function handleCopyCommand(text?: string): Promise<void> {
     if (text) {
         await vscode.env.clipboard.writeText(text);
         vscode.window.showInformationMessage('Analysis output copied to clipboard!');
+    }
+}
+
+async function handleReIngestCommand(
+    panel: vscode.WebviewPanel,
+    message: WebviewMessage,
+): Promise<void> {
+    const pathTrimmed = typeof message.path === 'string' ? message.path.trim() : '';
+    if (!pathTrimmed) {
+        WebviewService.showError(panel, 'Re-Ingest Failed', [
+            'No folder path provided. Close and run Analyze or Analyze This Folder again.',
+        ]);
+        return;
+    }
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(pathTrimmed));
+    if (!workspaceFolder) {
+        WebviewService.showError(panel, 'Re-Ingest Failed', [
+            'Folder is not in the workspace or no longer exists.',
+        ]);
+        return;
+    }
+    await processManager.killCurrentProcess();
+    try {
+        await AnalysisService.verifyDependencies(panel);
+        await AnalysisService.analyze(panel, pathTrimmed, 'Re-analyzing folder...');
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+        WebviewService.showError(panel, 'Re-Ingest Failed', [errorMessage]);
     }
 }
 

--- a/src/services/webviewService.ts
+++ b/src/services/webviewService.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { WEBVIEW_OPTIONS } from '../config';
-import { StatusMessage } from '../types';
+import { AnalysisResultData, StatusMessage } from '../types';
 import { handleWebviewMessage } from './messageHandler';
 import { getErrorContent, getLoadingContent, getResultsContent } from '../webview';
 
@@ -33,7 +33,7 @@ export class WebviewService {
         panel.webview.html = getErrorContent(title, errors);
     }
 
-    public static showResults(panel: vscode.WebviewPanel, data: any): void {
+    public static showResults(panel: vscode.WebviewPanel, data: AnalysisResultData): void {
         panel.webview.html = getResultsContent(data);
     }
 }

--- a/src/services/webviewService.ts
+++ b/src/services/webviewService.ts
@@ -33,7 +33,11 @@ export class WebviewService {
         panel.webview.html = getErrorContent(title, errors);
     }
 
-    public static showResults(panel: vscode.WebviewPanel, data: AnalysisResultData): void {
-        panel.webview.html = getResultsContent(data);
+    public static showResults(
+        panel: vscode.WebviewPanel,
+        data: AnalysisResultData,
+        ingestedPath?: string,
+    ): void {
+        panel.webview.html = getResultsContent(data, ingestedPath);
     }
 }

--- a/src/test/suite/config.test.ts
+++ b/src/test/suite/config.test.ts
@@ -1,0 +1,35 @@
+import * as assert from 'assert';
+import { COMMANDS, ERROR_MESSAGES, THEME, WEBVIEW_OPTIONS } from '../../config';
+
+describe('config', () => {
+    it('COMMANDS has expected command IDs', () => {
+        assert.strictEqual(COMMANDS.analyze, 'vscode-gitingest.analyze');
+        assert.strictEqual(COMMANDS.analyzeFolder, 'vscode-gitingest.analyzeFolder');
+        assert.strictEqual(COMMANDS.addToIngest, 'vscode-gitingest.addToIngest');
+    });
+
+    it('ERROR_MESSAGES key entries are non-empty strings', () => {
+        assert.ok(ERROR_MESSAGES.NO_WORKSPACE.length > 0);
+        assert.ok(ERROR_MESSAGES.PYTHON_NOT_INSTALLED.length > 0);
+        assert.ok(ERROR_MESSAGES.UNKNOWN_ERROR.length > 0);
+        assert.ok(ERROR_MESSAGES.PROCESS_KILL_FAILED.length > 0);
+    });
+
+    it('THEME has expected keys and string values', () => {
+        assert.strictEqual(typeof THEME.primary, 'string');
+        assert.strictEqual(typeof THEME.primaryHover, 'string');
+        assert.strictEqual(typeof THEME.danger, 'string');
+        assert.strictEqual(typeof THEME.dangerHover, 'string');
+        assert.strictEqual(typeof THEME.background, 'string');
+        assert.strictEqual(typeof THEME.border, 'string');
+        assert.strictEqual(typeof THEME.text, 'string');
+    });
+
+    it('WEBVIEW_OPTIONS.enableScripts is true', () => {
+        assert.strictEqual(WEBVIEW_OPTIONS.enableScripts, true);
+    });
+
+    it('WEBVIEW_OPTIONS.retainContextWhenHidden is false', () => {
+        assert.strictEqual(WEBVIEW_OPTIONS.retainContextWhenHidden, false);
+    });
+});

--- a/src/test/suite/config.test.ts
+++ b/src/test/suite/config.test.ts
@@ -6,6 +6,7 @@ describe('config', () => {
         assert.strictEqual(COMMANDS.analyze, 'vscode-gitingest.analyze');
         assert.strictEqual(COMMANDS.analyzeFolder, 'vscode-gitingest.analyzeFolder');
         assert.strictEqual(COMMANDS.addToIngest, 'vscode-gitingest.addToIngest');
+        assert.strictEqual(COMMANDS.reIngest, 'vscode-gitingest.reIngest');
     });
 
     it('ERROR_MESSAGES key entries are non-empty strings', () => {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,0 +1,28 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+describe('Extension', () => {
+    it('extension is present', () => {
+        const ext = vscode.extensions.getExtension('iamshreydxv.gitingest');
+        assert.ok(ext, 'Extension iamshreydxv.gitingest should be found');
+    });
+
+    it('extension activates', async () => {
+        const ext = vscode.extensions.getExtension('iamshreydxv.gitingest');
+        assert.ok(ext);
+        await ext.activate();
+        assert.ok(ext.isActive);
+    });
+
+    it('contributed commands are registered', async () => {
+        const commands = await vscode.commands.getCommands();
+        const gitingestCommands = [
+            'vscode-gitingest.analyze',
+            'vscode-gitingest.analyzeFolder',
+            'vscode-gitingest.addToIngest',
+        ];
+        for (const cmd of gitingestCommands) {
+            assert.ok(commands.includes(cmd), `Command ${cmd} should be registered`);
+        }
+    });
+});

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -15,11 +15,15 @@ describe('Extension', () => {
     });
 
     it('contributed commands are registered', async () => {
+        const ext = vscode.extensions.getExtension('iamshreydxv.gitingest');
+        assert.ok(ext);
+        await ext.activate();
         const commands = await vscode.commands.getCommands();
         const gitingestCommands = [
             'vscode-gitingest.analyze',
             'vscode-gitingest.analyzeFolder',
             'vscode-gitingest.addToIngest',
+            'vscode-gitingest.reIngest',
         ];
         for (const cmd of gitingestCommands) {
             assert.ok(commands.includes(cmd), `Command ${cmd} should be registered`);

--- a/src/test/suite/osUtils.test.ts
+++ b/src/test/suite/osUtils.test.ts
@@ -1,0 +1,79 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import { OsUtils } from '../../utils/osUtils';
+
+describe('OsUtils', () => {
+    it('isWindows returns true only on win32', () => {
+        const expected = process.platform === 'win32';
+        assert.strictEqual(OsUtils.isWindows(), expected);
+    });
+
+    it('isMac returns true only on darwin', () => {
+        const expected = process.platform === 'darwin';
+        assert.strictEqual(OsUtils.isMac(), expected);
+    });
+
+    it('isLinux returns true only on linux', () => {
+        const expected = process.platform === 'linux';
+        assert.strictEqual(OsUtils.isLinux(), expected);
+    });
+
+    it('exactly one of isWindows, isMac, isLinux is true', () => {
+        const count = [OsUtils.isWindows(), OsUtils.isMac(), OsUtils.isLinux()].filter(
+            Boolean,
+        ).length;
+        assert.strictEqual(count, 1);
+    });
+
+    it('getPythonCommands returns expected structure on Windows', () => {
+        const commands = OsUtils.getPythonCommands();
+        assert.ok(Array.isArray(commands));
+        assert.ok(commands.length >= 2);
+        if (OsUtils.isWindows()) {
+            assert.strictEqual(commands[0].cmd, 'py');
+            assert.deepStrictEqual(commands[0].args, ['-3']);
+            assert.strictEqual(commands[1].cmd, 'python');
+            assert.strictEqual(commands[2].cmd, 'python3');
+        } else {
+            assert.strictEqual(commands[0].cmd, 'python3');
+            assert.strictEqual(commands[1].cmd, 'python');
+        }
+        commands.forEach((c) => {
+            assert.ok(typeof c.cmd === 'string' && c.cmd.length > 0);
+            assert.ok(Array.isArray(c.args));
+        });
+    });
+
+    it('getVenvPythonPath contains venv path and correct executable name', () => {
+        const venvPath = path.join('my', 'venv');
+        const result = OsUtils.getVenvPythonPath(venvPath);
+        assert.ok(result.includes(venvPath));
+        if (OsUtils.isWindows()) {
+            assert.ok(result.includes('Scripts'));
+            assert.ok(result.endsWith('python.exe'));
+        } else {
+            assert.ok(result.includes('bin'));
+            assert.ok(result.endsWith('python'));
+        }
+    });
+
+    it('normalizePath converts backslashes to forward slashes', () => {
+        const input = 'a\\b\\c';
+        const result = OsUtils.normalizePath(input);
+        assert.strictEqual(result, 'a/b/c');
+    });
+
+    it('normalizePath normalizes path', () => {
+        const result = OsUtils.normalizePath('a/b/../c');
+        assert.strictEqual(result, 'a/c');
+    });
+
+    it('getPathSeparator returns backslash on Windows, slash elsewhere', () => {
+        const sep = OsUtils.getPathSeparator();
+        if (OsUtils.isWindows()) {
+            assert.strictEqual(sep, '\\');
+        } else {
+            assert.strictEqual(sep, '/');
+        }
+    });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,13 +25,16 @@ export interface StatusMessage {
     type: 'info' | 'success' | 'error' | 'warning';
 }
 
+/** Shape of the data payload shown in the results webview and saved to file. */
+export interface AnalysisResultData {
+    summary: string;
+    tree: string;
+    content: string;
+}
+
 export interface AnalysisResult {
     type: 'success' | 'error';
-    data?: {
-        summary: string;
-        tree: string;
-        content: string;
-    };
+    data?: AnalysisResultData;
     message?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,8 @@
 // Message types
 export interface WebviewMessage {
-    command: 'analyze' | 'cancel' | 'copy' | 'saveToFile' | 'retry';
+    command: 'analyze' | 'cancel' | 'copy' | 'saveToFile' | 'retry' | 'reIngest';
     text?: string;
+    path?: string;
     data?: {
         summary: string;
         tree: string;

--- a/src/utils/osUtils.ts
+++ b/src/utils/osUtils.ts
@@ -37,12 +37,6 @@ export class OsUtils {
         return path.join(venvPath, binFolder, pythonExe);
     }
 
-    static getVenvPipPath(venvPath: string): string {
-        const binFolder = this.isWindows() ? 'Scripts' : 'bin';
-        const pipExe = this.isWindows() ? 'pip.exe' : 'pip';
-        return path.join(venvPath, binFolder, pipExe);
-    }
-
     static async killProcess(pid: number): Promise<void> {
         if (this.isWindows()) {
             await execAsync(`taskkill /pid ${pid} /T /F`);

--- a/src/utils/pythonHandler.ts
+++ b/src/utils/pythonHandler.ts
@@ -1,14 +1,25 @@
-import { spawn } from 'child_process';
+import { spawn, ChildProcess } from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
 import { ERROR_MESSAGES } from '../config';
+import { processManager } from './processManager';
 import { OsUtils } from './osUtils';
 
 type RunResult = { stdout: string; stderr: string; code: number };
 
-async function runCommand(cmd: string, args: string[], cwd?: string): Promise<RunResult> {
+interface RunError extends Error {
+    code?: number;
+}
+
+function runCommand(
+    cmd: string,
+    args: string[],
+    cwd?: string,
+    onSpawn?: (child: ChildProcess) => void,
+): Promise<RunResult> {
     return new Promise((resolve, reject) => {
         const child = spawn(cmd, args, { cwd, shell: false });
+        onSpawn?.(child);
         let stdout = '';
         let stderr = '';
 
@@ -23,10 +34,10 @@ async function runCommand(cmd: string, args: string[], cwd?: string): Promise<Ru
             if (code === 0) {
                 resolve({ stdout, stderr, code: code ?? 0 });
             } else {
-                const error = new Error(
+                const error: RunError = new Error(
                     stderr || stdout || `Command failed: ${cmd} ${args.join(' ')}`,
                 );
-                (error as any).code = code;
+                error.code = code ?? undefined;
                 reject(error);
             }
         });
@@ -64,7 +75,7 @@ export class PythonHandler {
             return { cmd, args };
         });
         try {
-            return await (Promise as any).any(attempts);
+            return await Promise.any(attempts);
         } catch {
             throw new Error(ERROR_MESSAGES.PYTHON_NOT_INSTALLED);
         }
@@ -138,8 +149,8 @@ export class PythonHandler {
             }
             await runCommand(this.pythonCmd, [...this.pythonArgs, '-m', 'virtualenv', targetPath]);
             return true;
-        } catch (error: any) {
-            const msg = (error?.message || '').toLowerCase();
+        } catch (error: unknown) {
+            const msg = (error instanceof Error ? error.message : String(error)).toLowerCase();
             if (msg.includes('permission denied')) {
                 throw new Error(ERROR_MESSAGES.PERMISSION_ERROR);
             }
@@ -147,56 +158,41 @@ export class PythonHandler {
         }
     }
 
+    private async createVenvAndReturnPath(projectPath: string): Promise<string> {
+        const projectVenvPath = path.join(projectPath, '.venv');
+        const homeVenvPath = path.join(os.homedir(), '.gitingest-venv');
+        try {
+            await this.tryCreateVenvInPath(projectVenvPath);
+            return projectVenvPath;
+        } catch (error) {
+            if (error instanceof Error && error.message === ERROR_MESSAGES.PERMISSION_ERROR) {
+                console.log('Failed to create venv in project directory, trying home directory...');
+                try {
+                    await this.tryCreateVenvInPath(homeVenvPath);
+                    return homeVenvPath;
+                } catch {
+                    throw new Error(ERROR_MESSAGES.VENV_CREATION_FAILED);
+                }
+            }
+            throw error;
+        }
+    }
+
     private async createVirtualEnv(projectPath: string): Promise<void> {
         try {
-            // First try installing in user site-packages
             await this.installGitIngestUserSite();
             return;
-        } catch (error) {
-            // If user site-packages installation fails, try venv approach
+        } catch {
             console.log('User site-packages installation failed, trying venv...');
-
-            // First try in project directory
-            const projectVenvPath = path.join(projectPath, '.venv');
-
-            // Then try in user's home directory if project directory fails
-            const homeVenvPath = path.join(os.homedir(), '.gitingest-venv');
-
-            let venvCreated = false;
-            let finalVenvPath = '';
-
-            try {
-                await this.tryCreateVenvInPath(projectVenvPath);
-                venvCreated = true;
-                finalVenvPath = projectVenvPath;
-            } catch (error) {
-                if (error instanceof Error && error.message === ERROR_MESSAGES.PERMISSION_ERROR) {
-                    console.log(
-                        'Failed to create venv in project directory, trying home directory...',
-                    );
-                    try {
-                        await this.tryCreateVenvInPath(homeVenvPath);
-                        venvCreated = true;
-                        finalVenvPath = homeVenvPath;
-                    } catch (homeError) {
-                        throw new Error(ERROR_MESSAGES.VENV_CREATION_FAILED);
-                    }
-                } else {
-                    throw error;
-                }
-            }
-
-            if (venvCreated) {
-                this.venvPath = finalVenvPath;
-                this.venvPython = OsUtils.getVenvPythonPath(this.venvPath);
-
-                try {
-                    await runCommand(this.venvPython, ['-m', 'pip', 'install', '--upgrade', 'pip']);
-                    await runCommand(this.venvPython, ['-m', 'pip', 'install', 'gitingest']);
-                } catch (error) {
-                    throw new Error(ERROR_MESSAGES.GITINGEST_NOT_INSTALLED);
-                }
-            }
+        }
+        const venvPath = await this.createVenvAndReturnPath(projectPath);
+        this.venvPath = venvPath;
+        this.venvPython = OsUtils.getVenvPythonPath(this.venvPath);
+        try {
+            await runCommand(this.venvPython, ['-m', 'pip', 'install', '--upgrade', 'pip']);
+            await runCommand(this.venvPython, ['-m', 'pip', 'install', 'gitingest']);
+        } catch {
+            throw new Error(ERROR_MESSAGES.GITINGEST_NOT_INSTALLED);
         }
     }
 
@@ -222,26 +218,49 @@ export class PythonHandler {
         }
     }
 
+    private async getScriptCommandAndArgs(): Promise<{ cmd: string; baseArgs: string[] }> {
+        if (this.userSitePackages) {
+            if (!this.pythonCmd) {
+                const found = await this.findPythonCommand();
+                this.pythonCmd = found.cmd;
+                this.pythonArgs = found.args;
+            }
+            return { cmd: this.pythonCmd, baseArgs: [...this.pythonArgs] };
+        }
+        return { cmd: this.venvPython, baseArgs: [] };
+    }
+
     public async executeScript(scriptPath: string, args: string[]): Promise<string> {
         try {
-            let cmd: string;
-            let baseArgs: string[] = [];
-            if (this.userSitePackages) {
-                if (!this.pythonCmd) {
-                    const found = await this.findPythonCommand();
-                    this.pythonCmd = found.cmd;
-                    this.pythonArgs = found.args;
-                }
-                cmd = this.pythonCmd;
-                baseArgs = [...this.pythonArgs];
-            } else {
-                cmd = this.venvPython;
-            }
+            const { cmd, baseArgs } = await this.getScriptCommandAndArgs();
             const res = await runCommand(cmd, [...baseArgs, scriptPath, ...args]);
             return res.stdout;
         } catch (error) {
             console.error('Script execution failed:', error);
             throw error;
+        }
+    }
+
+    /**
+     * Runs the script and registers the child process with processManager so it can be killed on Cancel.
+     * Clears the process when the promise settles (success or failure).
+     * Sets cwd to args[0] (repo path) when valid, so the engine runs with project root as cwd on all OS.
+     */
+    public async executeScriptWithProcess(scriptPath: string, args: string[]): Promise<string> {
+        const { cmd, baseArgs } = await this.getScriptCommandAndArgs();
+        const fullArgs = [...baseArgs, scriptPath, ...args];
+        const repoPath = args[0];
+        const cwd =
+            typeof repoPath === 'string' && repoPath.trim().length > 0
+                ? repoPath.trim()
+                : undefined;
+        try {
+            const res = await runCommand(cmd, fullArgs, cwd, (child) =>
+                processManager.setProcess(child),
+            );
+            return res.stdout;
+        } finally {
+            processManager.clear();
         }
     }
 

--- a/src/webview/index.ts
+++ b/src/webview/index.ts
@@ -67,12 +67,23 @@ export function getLoadingContent(statusMessages: StatusMessage[]): string {
     return createHtmlDocument(content, getBaseStyles(THEME));
 }
 
-export function getResultsContent(data: {
-    summary: string;
-    tree: string;
-    content: string;
-}): string {
-    const content = `<div class="shadow-wrapper"><div class="content-wrapper"><div class="grid"><div>${Section({ title: 'Summary', content: escapeHtml(data.summary), copyFunction: 'copySummary()' })}<div class="button-group">${Button({ onClick: 'copyAll()', icon: icons.copy, children: 'Copy All' })}${Button({ onClick: 'saveToFile()', icon: icons.save, children: 'Save to File' })}</div></div>${Section({ title: 'Directory Structure', content: escapeHtml(data.tree), copyFunction: 'copyTree()' })}</div>${Section({ title: 'Files Content', content: escapeHtml(data.content), copyFunction: 'copyContent()' })}</div></div><script>function copySummary(){const summary=document.querySelectorAll('.scrollable-content pre')[0].innerText;vscode.postMessage({command:'copy',text:summary})}function copyTree(){const tree=document.querySelectorAll('.scrollable-content pre')[1].innerText;vscode.postMessage({command:'copy',text:tree})}function copyContent(){const content=document.querySelectorAll('.scrollable-content pre')[2].innerText;vscode.postMessage({command:'copy',text:content})}function copyAll(){const allContent=[document.querySelectorAll('.scrollable-content pre')[0].innerText,document.querySelectorAll('.scrollable-content pre')[1].innerText,document.querySelectorAll('.scrollable-content pre')[2].innerText].join('\\n\\n');vscode.postMessage({command:'copy',text:allContent})}function saveToFile(){const summary=document.querySelectorAll('.scrollable-content pre')[0].innerText;const tree=document.querySelectorAll('.scrollable-content pre')[1].innerText;const content=document.querySelectorAll('.scrollable-content pre')[2].innerText;vscode.postMessage({command:'saveToFile',data:{summary,tree,content}})}</script>`;
+export function getResultsContent(
+    data: {
+        summary: string;
+        tree: string;
+        content: string;
+    },
+    ingestedPath?: string,
+): string {
+    const ingestedPathTrimmed = ingestedPath?.trim() ?? '';
+    const reIngestButton = ingestedPathTrimmed
+        ? Button({ onClick: 'reIngest()', icon: icons.retry, children: 'Re-Ingest' })
+        : '';
+    const pathScript = ingestedPathTrimmed
+        ? `const lastIngestedPath=${JSON.stringify(ingestedPathTrimmed)};function reIngest(){if(lastIngestedPath)vscode.postMessage({command:'reIngest',path:lastIngestedPath})}`
+        : '';
+    const buttonGroup = `<div class="button-group">${Button({ onClick: 'copyAll()', icon: icons.copy, children: 'Copy All' })}${Button({ onClick: 'saveToFile()', icon: icons.save, children: 'Save to File' })}${reIngestButton}</div>`;
+    const content = `<div class="shadow-wrapper"><div class="content-wrapper"><div class="grid"><div>${Section({ title: 'Summary', content: escapeHtml(data.summary), copyFunction: 'copySummary()' })}${buttonGroup}</div>${Section({ title: 'Directory Structure', content: escapeHtml(data.tree), copyFunction: 'copyTree()' })}</div>${Section({ title: 'Files Content', content: escapeHtml(data.content), copyFunction: 'copyContent()' })}</div></div><script>function copySummary(){const summary=document.querySelectorAll('.scrollable-content pre')[0].innerText;vscode.postMessage({command:'copy',text:summary})}function copyTree(){const tree=document.querySelectorAll('.scrollable-content pre')[1].innerText;vscode.postMessage({command:'copy',text:tree})}function copyContent(){const content=document.querySelectorAll('.scrollable-content pre')[2].innerText;vscode.postMessage({command:'copy',text:content})}function copyAll(){const allContent=[document.querySelectorAll('.scrollable-content pre')[0].innerText,document.querySelectorAll('.scrollable-content pre')[1].innerText,document.querySelectorAll('.scrollable-content pre')[2].innerText].join('\\n\\n');vscode.postMessage({command:'copy',text:allContent})}function saveToFile(){const summary=document.querySelectorAll('.scrollable-content pre')[0].innerText;const tree=document.querySelectorAll('.scrollable-content pre')[1].innerText;const content=document.querySelectorAll('.scrollable-content pre')[2].innerText;vscode.postMessage({command:'saveToFile',data:{summary,tree,content}})}${pathScript}</script>`;
     return createHtmlDocument(content, getBaseStyles(THEME));
 }
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "module": "commonjs",
+        "outDir": "out",
+        "rootDir": "src",
+        "types": ["node", "mocha"]
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
Added

- **.gitingestignore** support: same format as `.gitignore`; the gitingest engine respects both `.gitignore` and `.gitingestignore` when building the digest. Exclude files from ingestion without adding them to `.gitignore`.
- **Settings support** for exclusions: setting `gitingest.fileExclusions` (glob patterns, defaults: `**/node_modules`, `**/.git`) to exclude more paths from ingestion; applied in addition to ignore files.
- **Re-Ingest:** Re-run ingest on the same folder without reselecting. Use the **Re-Ingest** button in the results panel after viewing a digest, or run **GitIngest: Re-Ingest Last Folder** from the Command Palette. Useful after making changes when you don't want to go through the selection process again.
- Resolved suggestion: https://github.com/ShreyPurohit/gitingest-vsextension/discussions/8#discussion-9529211

Changed

- **Handler:** Cancel / closing the panel now properly stops the running ingest process; script runs with the repo root as working directory; shared command/args logic and clearer error handling in the Python handler.
- **Services:** Analysis service validates the repo path and reads workspace file-exclusion settings before running; webview and result types tightened up; removed unused config and helpers.

Fixed

- Resolved 3 high-severity npm audit issues in dev dependencies (serialize-javascript) via override; tests unchanged.
- VSIX no longer ships test-only config (`tsconfig.*.json` excluded) for a smaller package.